### PR TITLE
Start streaming cloudwatch logs with a valid, recent timestamp

### DIFF
--- a/runner/cloudwatch.go
+++ b/runner/cloudwatch.go
@@ -149,11 +149,12 @@ func (lw *logWatcher) Watch(ctx context.Context) error {
 		Timeout:        lw.Timeout,
 	}
 
+	after := time.Now().Unix() * 1000
+
 	if err := waiter.Wait(ctx); err != nil {
 		return err
 	}
 
-	var after int64
 	var err error
 
 	pollInterval := lw.Interval


### PR DESCRIPTION
The issue we've been seeing with `ecs-run-task` is due to a change in the cloudwatch logs API.

It now appears to fail if a `FilterLogEventsPages` is provided a zero `StartTime`. Previously this would work fine, but now it seems to fail silently without returning events.

The fix here is to simply provide the time from prior to creating the event stream, which is close enough to kick things off.

